### PR TITLE
Improve API

### DIFF
--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -163,11 +163,12 @@ class Api
     public function createItem(string $collectionId, array $fields)
     {
         $defaults = [
-        "_archived" => false,
-        "_draft" => false,
+            "_archived" => false,
+            "_draft" => false,
         ];
+
         return $this->post("/collections/{$collectionId}/items", [
-          'fields' => $defaults + $fields,
+          'fields' => array_merge($defaults, $fields),
         ]);
     }
 

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -174,7 +174,9 @@ class Api
 
     public function updateItem(string $collectionId, string $itemId, array $fields)
     {
-        return $this->put("/collections/{$collectionId}/items/{$itemId}", $fields);
+        return $this->put("/collections/{$collectionId}/items/{$itemId}", [
+            'fields' => $fields,
+        ]);
     }
 
     public function removeItem(string $collectionId, $itemId)

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -76,9 +76,9 @@ class Api
         return $this->request($path, "PUT", $data);
     }
 
-    private function delete($path, $data)
+    private function delete($path)
     {
-        return $this->request($path, "DELETE", $data);
+        return $this->request($path, "DELETE");
     }
 
     private function parse($response)


### PR DESCRIPTION
This introduces two small (and one large) improvements to the API:

1. allow `_archived` and `_draft` to be provided in `createItem()`
2. automatically nest `$fields` in `field` attribute, in `updateItem()`
3. allow `removeItem()` to be called