### PR TITLE
Added HTTP PATCH method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ $webflow->createItem($collectionId, $fields);
 $webflow->updateItem($collectionId, $itemId, $fields);
 ```
 
+### Patch Collection Item
+```
+$webflow->patchItem($collectionId, $itemId, $fields);
+```
+
 ### Remove Collection Item
 ```
 $webflow->removeItem($collectionId, $itemId);

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -76,6 +76,11 @@ class Api
         return $this->request($path, "PUT", $data);
     }
 
+    private function patch($path, $data)
+    {
+        return $this->request($path, "PATCH", $data);
+    }
+
     private function delete($path)
     {
         return $this->request($path, "DELETE");
@@ -175,6 +180,13 @@ class Api
     public function updateItem(string $collectionId, string $itemId, array $fields, bool $live = false)
     {
         return $this->put("/collections/{$collectionId}/items/{$itemId}" . ($live ? "?live=true" : ""), [
+            'fields' => $fields,
+        ]);
+    }
+
+    public function patchItem(string $collectionId, string $itemId, array $fields, bool $live = false)
+    {
+        return $this->patch("/collections/{$collectionId}/items/{$itemId}" . ($live ? "?live=true" : ""), [
             'fields' => $fields,
         ]);
     }


### PR DESCRIPTION
When I used this repo for my project, I realized there was only the UPDATE method, which requires that all item fields be passed when making changes to the Webflow CMS, even those that were not updated.

The PATCH method does not require you to pass all the item fields, so you can just pass the fields you need to update, making it extremely useful.