### PR TITLE
Update Code for Publish for simpler workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $webflow->sites();
 
 ### List Collections
 ```
-$webflow->collections();
+$webflow->collections($siteid);
 ```
 
 ### Get All Items for a Collection (including paginated results)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ $webflow->removeItem($collectionId, $itemId);
 ```
 
 ### Publish Site
+Before changes go live, you must publish them to your domains.
 ```
 $webflow->publishSite($siteId,['domains' => ['mydomain.webflow.io', 'mycustomdomain.example.com']]);
 ```

--- a/README.md
+++ b/README.md
@@ -37,12 +37,7 @@ $webflow->sites();
 
 ### Get Specific Site
 ```
-$webflow->site($siteid);
-```
-
-### Publish Site
-```
-$webflow->publishSite($siteid,['domains' => ['mydomain.webflow.io', 'mycustomdomain.example.com']]);
+$webflow->site($siteId);
 ```
 
 ### List Domains
@@ -85,9 +80,10 @@ $webflow->updateItem($collectionId, $itemId, $fields);
 $webflow->removeItem($collectionId, $itemId);
 ```
 
-Publish Your Site
---
-
+### Publish Site
+```
+$webflow->publishSite($siteId,['domains' => ['mydomain.webflow.io', 'mycustomdomain.example.com']]);
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ $webflow->info();
 $webflow->sites();
 ```
 
+### Get Specific Site
+```
+$webflow->site($siteid);
+```
+
+### Publish Site
+```
+$webflow->publishSite($siteid,['domains' => ['mydomain.webflow.io', 'mycustomdomain.example.com']]);
+```
+
+### List Domains
+```
+$webflow->domains($siteid);
+```
+__If you only have a webflow.io domain this will return an empty array []__
+
+
 ### List Collections
 ```
 $webflow->collections($siteid);
@@ -67,6 +84,11 @@ $webflow->updateItem($collectionId, $itemId, $fields);
 ```
 $webflow->removeItem($collectionId, $itemId);
 ```
+
+Publish Your Site
+--
+
+
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Before changes go live, you must publish them to your domains.
 ```
 $webflow->publishSite($siteId,['domains' => ['mydomain.webflow.io', 'mycustomdomain.example.com']]);
 ```
+You can also simply pass a list of domains to the publishSite method
+````
+$webflow->publishSite($siteId,['mydomain.webflow.io', 'mycustomdomain.example.com']);
+````
 
 
 

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -117,6 +117,9 @@ class Api
 
     public function publishSite(string $siteId, array $domains)
     {
+        if (!isset($domains['domains'])){
+            $domains = ['domains' => $domains];
+        }
         return $this->post("/sites/${siteId}/publish", $domains);
     }
 


### PR DESCRIPTION
I updated the code for publish so that it can be called with or without the 'domains' key

Both will work

````
$webflow->publishSite($siteId, ['domains' => ['mydomain.webflow.io', 'example.com']]);

$webflow->publishSite($siteId,['mydomain.webflow.io', 'example.com']);
````

Allow for a slightly more intuitive calling.

Additionally I have added a few more calls to the Readme.md to highlight other methods.