### PR TITLE
[V2 Api] Basic changes required for api v2 to work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 composer.phar
 /vendor/
+/.idea
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Implementation based on [Webflow CMS API Reference](https://developers.webflow.c
 - Patch Collection Item
 - Remove Collection Item
 
+## Version 2
+
+This package is now using Version 2 of the Webflow Api.
+
 ## Usage
 
 Check https://university.webflow.com/article/using-the-webflow-cms-api on how to generate `YOUR_WEBFLOW_API_TOKEN`
@@ -68,6 +72,24 @@ $webflow->updateItem($collectionId, $itemId, $fields);
 $webflow->removeItem($collectionId, $itemId);
 ```
 
+## Publising
+
+### Publishing Items
+Publishing an item or items can be done instead of publishing the entire site.
+```php
+$webflow->publishItem($collectionId, $itemIds);
+```
+
+### Publishing a Site
+
+```php
+$domains = [$domainID];
+// if you wish to publish to your mydomain.webflow.io subdomain you should specify
+// true.  If true $domains **must** be an empty array
+$publishWebflowSubdomain = true;
+$webflow->publishSite($siteId,$domains, $publishWebflowSubdomain)
+```
+**nb:** Webflow has very strict limits on publishing your site. Currently 1 per minute.
 
 ## Installation
 

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -178,20 +178,30 @@ class Api
         return $this->get("/collections/{$collectionId}/items/{$itemId}");
     }
 
-    public function createItem(string $collectionId, array $fields, bool $live = false)
+    public function createItem(string $collectionId,  $fields, bool $live = false)
     {
         $defaults = [
             "isArchived" => false,
             "isDraft" => false,
         ];
+        $data =  (object) [
+            'fieldData' => [],
+          ];
+        $data->fieldData = $fields;
         return $this->post("/collections/{$collectionId}/items" . ($live ? "?live=true" : ""),
-            (object)  $fields
+          $data
         );
+
     }
 
     public function updateItem(string $collectionId, string $itemId, array $fields, bool $live = false)
     {
-         return $this->patch("/collections/{$collectionId}/items/{$itemId}" . ($live ? "?live=true" : ""),  (object)  $fields);
+              $data =  (object) [
+            'fieldData' => [],
+          ];
+        $data->fieldData = $fields;
+
+         return $this->patch("/collections/{$collectionId}/items/{$itemId}" . ($live ? "?live=true" : ""),  $data);
 
     }
 

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -34,7 +34,7 @@ class Api
         return $this;
     }
 
-    private function request(string $path, string $method, array $data = [])
+    private function request(string $path, string $method,   $data = [])
     {
         $curl = curl_init();
         $options = [
@@ -52,6 +52,7 @@ class Api
         ];
         if (!empty($data)) {
             $json = json_encode($data);
+
             $options[CURLOPT_POSTFIELDS] = $json;
             $options[CURLOPT_HTTPHEADER][] = "Content-Length: " . strlen($json);
         }
@@ -59,7 +60,7 @@ class Api
         $response = curl_exec($curl);
         curl_close($curl);
         list($headers, $body) = explode("\r\n\r\n", $response, 2);
-        ray(['reaspnos body', $body]);
+
         return $this->parse($body);
     }
     private function get($path)
@@ -125,6 +126,13 @@ class Api
     public function publishSite(string $siteId, array $domains)
     {
         return $this->post("/sites/${siteId}/publish", $domains);
+    }
+
+    public function publishItem(string $collection_id, array $itemIds)
+    {
+        return $this->post("/collections/{$collection_id}/items/publish", [
+            'itemIds' => $itemIds,
+        ]);
     }
 
     // Collections

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -149,6 +149,12 @@ class Api
         return $this->post("/sites/${siteId}/publish", $data);
     }
 
+  /**
+   * Publish just the items specified, rather than the entire site
+   * @param string $collection_id
+   * @param array $itemIds
+   * @return mixed
+   */
     public function publishItem(string $collection_id, array $itemIds)
     {
         return $this->post("/collections/{$collection_id}/items/publish", [
@@ -205,6 +211,7 @@ class Api
         $data =  (object) [
             'fieldData' => [],
           ];
+        // must be an object property
         $data->fieldData = $fields;
         return $this->post("/collections/{$collectionId}/items" . ($live ? "?live=true" : ""),
           $data
@@ -212,15 +219,22 @@ class Api
 
     }
 
+  /**
+   * Version 2 update item patches the item so you do not need to provide all details.
+   * @param string $collectionId
+   * @param string $itemId
+   * @param array $fields
+   * @param bool $live
+   * @return mixed
+   */
     public function updateItem(string $collectionId, string $itemId, array $fields, bool $live = false)
     {
-              $data =  (object) [
-            'fieldData' => [],
-          ];
+        $data =  (object) [
+          'fieldData' => [],
+        ];
+        // must be an object property
         $data->fieldData = $fields;
-
          return $this->patch("/collections/{$collectionId}/items/{$itemId}" . ($live ? "?live=true" : ""),  $data);
-
     }
 
     public function removeItem(string $collectionId, $itemId)

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -126,9 +126,31 @@ class Api
         return $this->get("/sites/{$siteId}/domains");
     }
 
-    public function publishSite(string $siteId, array $domains)
+    /**
+     * Publish site must take an array list of customdomains to be published to
+     * and a boolean indicating if your webflow.io subdomain should be published to
+     * @param string $siteId
+     * @param array $domains
+     * @param $publishWebflowSubdomain
+     * @return mixed
+     */
+    public function publishSite(string $siteId, array $domains, $publishWebflowSubdomain =  false)
     {
-        return $this->post("/sites/${siteId}/publish", $domains);
+        if (isset($domains['domains'])){
+            // backwards compatibility v1
+            $data = ['customDomains' => $domains['domains']];
+        } else {
+            // if  domains empty array then
+            if  (!$domains){
+                $data = [];
+            } else {
+                $data = ['customDomains' => $domains];
+            }
+        }
+
+        $data['publishToWebflowSubdomain'] = $publishWebflowSubdomain;
+
+        return $this->post("/sites/${siteId}/publish", $data);
     }
 
     public function publishItem(string $collection_id, array $itemIds)

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -170,8 +170,8 @@ class Api
     public function createItem(string $collectionId, array $fields, bool $live = false)
     {
         $defaults = [
-            "_archived" => false,
-            "_draft" => false,
+            "isArchived" => false,
+            "isDraft" => false,
         ];
 
         return $this->post("/collections/{$collectionId}/items" . ($live ? "?live=true" : ""), [

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -95,12 +95,12 @@ class Api
     private function parse($response)
     {
         $json = json_decode($response);
-        if (isset($json->code) && isset($json->msg)) {
-            $error = $json->msg;
-            if (isset($json->problems)) {
-                $error .= PHP_EOL . implode(PHP_EOL, $json->problems);
+        if (isset($json->code) && isset($json->message)) {
+            $error = $json->message;
+            if (isset($json->details)) {
+                $error .= PHP_EOL . $json->code . ': ' . implode(PHP_EOL, $json->details) ;
             }
-            throw new \Exception($error, $json->code);
+            throw new \Exception($error);
         }
         return $json;
     }

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -173,10 +173,9 @@ class Api
             "isArchived" => false,
             "isDraft" => false,
         ];
-
-        return $this->post("/collections/{$collectionId}/items" . ($live ? "?live=true" : ""), [
-            'fields' => array_merge($defaults, $fields),
-        ]);
+        return $this->post("/collections/{$collectionId}/items" . ($live ? "?live=true" : ""),
+            (object)  $fields
+        );
     }
 
     public function updateItem(string $collectionId, string $itemId, array $fields, bool $live = false)

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -6,6 +6,9 @@ use Webflow\WebflowException;
 
 class Api
 {
+      // changed api endpoints
+    // https://docs.developers.webflow.com/data/changelog/webflow-api-changed-endpoints
+    // https://docs.developers.webflow.com/data/reference/
     const WEBFLOW_API_ENDPOINT = 'https://api.webflow.com/v2';
     const WEBFLOW_API_USERAGENT = 'Expertlead Webflow PHP SDK (https://github.com/expertlead/webflow-php-sdk)';
 

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -188,12 +188,9 @@ class Api
 
     public function updateItem(string $collectionId, string $itemId, array $fields, bool $live = false)
     {
-       // ray(['fields for updateitem', $fields]);
-       // unset($fields['_id']);
          $item =$this->patch("/collections/{$collectionId}/items/{$itemId}" . ($live ? "?live=true" : ""), [
             'fields' => $fields,
         ]);
-         //ray(['updateitem', $item]);
          return $item;
     }
 

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -23,7 +23,7 @@ class Api
 
     public function __construct(
         $token,
-        $version = '1.0.0'
+        $version = '2.0.0'
     ) {
         if (empty($token)) {
             throw new WebflowException('token');

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -136,17 +136,13 @@ class Api
      */
     public function publishSite(string $siteId, array $domains, $publishWebflowSubdomain =  false)
     {
-        if (isset($domains['domains'])){
-            // backwards compatibility v1
-            $data = ['customDomains' => $domains['domains']];
+        // if  domains empty array then
+        if  (!$domains){
+            $data = [];
         } else {
-            // if  domains empty array then
-            if  (!$domains){
-                $data = [];
-            } else {
-                $data = ['customDomains' => $domains];
-            }
+            $data = ['customDomains' => $domains];
         }
+
 
         $data['publishToWebflowSubdomain'] = $publishWebflowSubdomain;
 

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -188,10 +188,8 @@ class Api
 
     public function updateItem(string $collectionId, string $itemId, array $fields, bool $live = false)
     {
-         $item =$this->patch("/collections/{$collectionId}/items/{$itemId}" . ($live ? "?live=true" : ""), [
-            'fields' => $fields,
-        ]);
-         return $item;
+         return $this->patch("/collections/{$collectionId}/items/{$itemId}" . ($live ? "?live=true" : ""),  (object)  $fields);
+
     }
 
     public function removeItem(string $collectionId, $itemId)


### PR DESCRIPTION
This is a first go at a V2 upgrade of the library. @wivern-co-uk 

This is the basic changes I needed to make to ensure that the V2 api works with my code. There may be things in the existing code that are broken that I have missed as my code doesnt touch them.

I have put some comments in the code on things that I am looking for feedback on (feedback on anything else is also welcomed)

- #18 

## Updates

Basically I have made the following updates

- Endpoint has been changed.
- Changed any relevant field names that are in the code eg `_draft` to `isDraft`
- Create and Update item `fields` changed to `fieldData`
- Some function parameter types changed to mixed 
- error parse code updated to new fields.
- Added `publishItem` which allows a collection item to be published rather than entire site.

## Issues

- If library is released it should be released at a new Major version as it will break existing installations.
- Non library code needs to be changed quite substantially, the layout of data returned from webflow has changed.  eg Data I think used to be returned a root eg

````
{
  id: 12345abcdef
  name: 'this is the name'
  otherfields : 'otehr fields'
}
````

now the structure is 

````
{
  id: 12345abcdef
fieldData: {
  name: 'this is the name'
  otherfields : 'otehr fields'
}
}
````


## Setup

In order to use the V2 library you simply need to go to webflow and generate a new V2 api key and use that.

User will need to make some changes to their own code in structure and field names.

## Changes 

Some notes on what moving to V2 means for people with codebases.  These are notes based on my experience and probably not comprehensive.

[https://docs.developers.webflow.com/data/changelog/webflow-api-changed-endpoints](https://docs.developers.webflow.com/data/changelog/webflow-api-changed-endpoints)

### Field Names

- Any field name that begins with `_` has been changed. 
- All fields are now camelCase
- Field data is now one level down below `fieldData` property.

### Methods


### Retrieving Items

```php
$webflow->itemsAll($collectionId);
$webflow->item($collectionId, $itemId);
```
now return a differnt structure.  Meta data is at the top level and the fields are one level below in a `fieldData` property.  This will require changes to client code.

### Publish Site

Publish site used to require that you passed an array containing  a sub array 'domains' this has now changed and it just requires the user to pass a list of domain strings or domain ids

### Publish Item

This is  a new api end point for V2 and allows items in collections to be published without publishing the entire site.

